### PR TITLE
docs: use Cv.drawMarker in notebooks

### DIFF
--- a/notebooks/pose_estimation_image_sequence.livemd
+++ b/notebooks/pose_estimation_image_sequence.livemd
@@ -263,7 +263,12 @@ defmodule PoseEstimation.Keypoint do
         acc_mat
 
       point, acc_mat ->
-        acc_mat |> Cv.circle({trunc(point.x), trunc(point.y)}, 2, Color.red(), thickness: 2)
+        acc_mat
+        |> Cv.drawMarker({trunc(point.x), trunc(point.y)}, Color.red(),
+          markerSize: 2,
+          markerType: Cv.Constant.cv_MARKER_SQUARE(),
+          thickness: 2
+        )
     end)
   end
 

--- a/notebooks/pose_estimation_single_image.livemd
+++ b/notebooks/pose_estimation_single_image.livemd
@@ -214,13 +214,12 @@ keypoint_edges =
 draw_keypoints = fn %Cv.Mat{} = input_image_mat, keypoints ->
   for %{x: x, y: y} <- keypoints, reduce: input_image_mat do
     acc_mat ->
-      Cv.circle(
+      Cv.drawMarker(
         acc_mat,
         {trunc(x), trunc(y)},
-        3,
         {0, 0, 255},
-        thickness: 5,
-        lineType: Cv.Constant.cv_FILLED()
+        markerSize: 10,
+        thickness: 3
       )
   end
 end


### PR DESCRIPTION
I believe Cv.drawMarker is more semantically correct than Cv.Circle for plotting keypoints. The resulting images will be almost the same.