### PR TITLE
docs: Correct links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ iex> ImageClassification.predict(pid, "test/test_data/parrot.jpeg", top_k: 3)
 
 [![Nerves](https://github-actions.40ants.com/cocoa-xu/tflite_elixir/matrix.svg?only=nerves-build)](https://github.com/cocoa-xu/tflite_elixir/actions)
 
-Prebuilt firmwares are available [here](https://github.com/cocoa-xu/tflite_elixir/releases).
+Prebuilt firmwares are available [here](https://github.com/cocoa-xu/tflite_elixir/releases). Nightly builds can be found [here](https://github.com/cocoa-xu/tflite_elixir/actions/workflows/nerves-build.yml?query=is%3Asuccess).
 
 Select the most recent run and scroll down to the `Artifacts` section, download the firmware file for your board and run
 

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ iex> ImageClassification.predict(pid, "test/test_data/parrot.jpeg", top_k: 3)
 
 ### Prebuilt firmware (Experimental)
 
-[![Nerves](https://github-actions.40ants.com/cocoa-xu/tflite_elixir/matrix.svg?only=nerves-build)](https://github.com/cocoa-xu/tflite_elixir)
+[![Nerves](https://github-actions.40ants.com/cocoa-xu/tflite_elixir/matrix.svg?only=nerves-build)](https://github.com/cocoa-xu/tflite_elixir/actions)
 
-Prebuilt firmwares are available [here](https://github.com/cocoa-xu/tflite_elixir/actions/workflows/nerves-build.yml?query=is%3Asuccess).
+Prebuilt firmwares are available [here](https://github.com/cocoa-xu/tflite_elixir/releases).
 
 Select the most recent run and scroll down to the `Artifacts` section, download the firmware file for your board and run
 


### PR DESCRIPTION
This is a proposal to improve a few links in the README.md.

Currently the link to the Nerves firmware seems incorrect. It navigates to the CI page. I believe the correct one is https://github.com/cocoa-xu/tflite_elixir/releases.

Also the nerves-build badge is currently linked to this repo's main page, but it might make more sense if it navigates to the CI page.