### PR TITLE
Remove unneeded require Logger

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,5 @@
 defmodule TFLiteElixir.MixProject do
   use Mix.Project
-  require Logger
 
   @app :tflite_elixir
   @version "0.3.9"


### PR DESCRIPTION
This emits a warning in any project using this with Elixir 1.20. :)