### PR TITLE
ci(nerves): build in the hexpm image nerves_livebook uses, drop dead targets

### DIFF
--- a/.github/workflows/nerves-build.yml
+++ b/.github/workflows/nerves-build.yml
@@ -86,15 +86,6 @@ jobs:
           - pair:
               target: bbb
               libedgetpu_library: armv7l
-          - pair:
-              target: osd32mp1
-              libedgetpu_library: armv7l
-          - pair:
-              target: npi_imx6ull
-              libedgetpu_library: armv7l
-          - pair:
-              target: grisp2
-              libedgetpu_library: armv7l
 
     steps:
       - name: Checkout

--- a/.github/workflows/nerves-build.yml
+++ b/.github/workflows/nerves-build.yml
@@ -45,13 +45,15 @@ permissions:
 jobs:
   mix-firmware:
     runs-on: ubuntu-latest
+    container: hexpm/elixir:1.20.2-erlang-29.0.2-ubuntu-resolute-20260610
     env:
       MIX_ENV: prod
       NERVES_PROJ_NAME: nerves_tflite
-      NERVES_LIVEBOOK_VER: "v0.19.2"
+      NERVES_LIVEBOOK_VER: "v0.19.5"
       TFLITE_BEAM_PREFER_PRECOMPILED: "true"
       TFLITE_BEAM_CORAL_SUPPORT: "true"
       FWUP_VERSION: "1.16.0"
+      DEBIAN_FRONTEND: noninteractive
 
     strategy:
       fail-fast: false
@@ -98,21 +100,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: "29"
-          elixir-version: "1.20"
-
       - name: Install nerves and system dependecies
         run: |
           mkdir -p ~/.ssh
           echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCulZpVE/JdpWX53C35n45RSIMtaIIiTMnmRo5oDEMbyh0NnKI5byikkOvGnGLOO2KTlq4We+MF5iKx72B1Ixl8RY7L6Kc/h3R6jG4uOWBhw/WBhIebteJVYDzrlU8fHTewquWYT6tJ7v7g54Qe5vofsDeKBDqTJqJPlwNSxP8AjPZ0vQ4O4IhG0CXaDzU/G50sqzquKckgGWURLN9LcsA+kzciKJRhKw4Q7kpOiTNG/fzYxBpgpNrnyyr7bhj0jdOsg9KoG57aLSqbmEVCOyWa6yh6lOTp37S6ijBfQORxUu3I+6B04zUBSEvN4wgqslHU9pbIio8Szz1vbnlqsgO0tG1yqALfs6RVSjW81AujKefeH/8seE7q0yiHJXkE4tejIcewJT+2e6p/fP2pVSwyRqZ1bObtRUCMG3Pwdi0IpfsyBSa02Qc7eT9VB1WN7XD1vpfMDQ/nIWmoA40VkX3F3v5Mht5PZwVmlRyM8BrLtCYTreUP5xl6ZZCSX2IfOI8= nerves-ci-build' > ~/.ssh/id_rsa.pub
-          sudo apt-get update && sudo apt-get install -y build-essential automake autoconf pkg-config bc m4 unzip zip curl git libssl-dev libncurses5-dev python3 ca-certificates squashfs-tools ssh-askpass libmnl-dev
+          apt-get update && apt-get install -y build-essential automake autoconf pkg-config bc m4 unzip zip curl wget file jq xdelta3 git libssl-dev libncurses5-dev python3 ca-certificates squashfs-tools ssh-askpass libmnl-dev libnl-genl-3-dev
           mix local.hex --force
           mix local.rebar --force
           mix archive.install hex nerves_bootstrap --force
           curl -fSL "https://github.com/fwup-home/fwup/releases/download/v${FWUP_VERSION}/fwup_${FWUP_VERSION}_amd64.deb" -o "fwup_${FWUP_VERSION}_amd64.deb"
-          sudo dpkg -i "fwup_${FWUP_VERSION}_amd64.deb"
+          dpkg -i "fwup_${FWUP_VERSION}_amd64.deb"
 
       - name: Make a nerves project
         run: |


### PR DESCRIPTION
`nerves-build` has been red since 2026-06-30. Two independent causes.

### 1. Build in the image nerves_livebook itself uses

The firmware build died on `aws_credentials`, a transitive dependency of
nerves_livebook:

```
compile: warnings being treated as errors
aws_credentials.erl:6:2: the callback gen_server:format_status(_,_) is deprecated
```

`aws_credentials` is not at fault. Its rebar.config declares the `rebar3_lint`
plugin, which pulls `elvis_core` 3.0.1, which requires `katana_code "~> 2.0.2"` —
a range locked to the 2.0.x line. That version sets `warnings_as_errors`, and its
`ktn_dodger.erl` still uses a bare `catch` that OTP 29 rejects. The plugin failure
is logged as non-fatal, but its `warnings_as_errors` carries into the
`aws_credentials` compile that follows and turns a harmless deprecation into an
error. Later katana_code releases fixed the `catch`; `~> 2.0.2` can never reach them.

Downgrading OTP is not available: Nerves requires the host OTP major to match the
target system's, and OTP 28 fails earlier with `** (Mix) Major version mismatch
between host and target Erlang/OTP versions`.

nerves_livebook builds this same dependency on the same OTP without trouble, so
this adopts their environment — the hexpm image pinned in their CircleCI config —
and drops `setup-beam`, which was resolving to the identical OTP 29.0.2 / Elixir
1.20.2 the image already carries. The container runs as root, so `sudo` is gone,
and the package list picks up the extras their build installs.
`NERVES_LIVEBOOK_VER` moves to v0.19.5 to match the release that image is known
to build.

### 2. Drop targets that no longer exist upstream

`osd32mp1`, `npi_imx6ull` and `grisp2` fail with `** (Mix) Environment variable
$NERVES_SYSTEM is not set.` — nerves_livebook has no `nerves_system_*` dependency
for them any more. It now covers bbb, mangopi_mq_pro, rpi, rpi0, rpi0_2, rpi2,
rpi3, rpi3a, rpi4, rpi5, trellis and x86_64. These three were already failing this
way before the container switch, so it is a separate, older breakage.

### Result

2/12 green → **9/9 green**, with real firmware artifacts (56–66 MB each) uploaded
for every target.

`mangopi_mq_pro` (RISC-V) is now available upstream and could be added later, but
libedgetpu ships no riscv64 library, so it is left out of this change.
